### PR TITLE
Preenchendo o estado do uploaded files close#35

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,6 +6,7 @@
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",
+    "lodash": "^4.17.20",
     "react": "^16.13.1",
     "react-circular-progressbar": "^2.0.3",
     "react-dom": "^16.13.1",

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,4 +1,5 @@
 import React, { Component } from "react";
+import { uniqueId } from 'lodash';
 
 import GlobalStyle from './components/styles/global';
 import { Container, Content } from './styles';
@@ -12,7 +13,10 @@ class App extends Component {
   };
 
 handleUpload = files => {
-  console.log(files)
+  const uploadedFiles = fles.map(file => ({
+    file,
+    id: uniqueId()
+  }))
 };
 
   render() {

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -6620,7 +6620,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
-lodash@^4.17.19:
+lodash@^4.17.19, lodash@^4.17.20:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==


### PR DESCRIPTION
Preenchendo o estado de uploaded files,independente do arquivo ter finalizado ou não, mesmo se der erro mostrar barra de progresso, configurando o handleUpload, anotar informações se esse arquivo já tem link, per correr essa listagem
sempre que eu acessar essa propriedade files , ai o nosso back-end vai entender que foi feito upload vamos gerar um ID pra isso , vamos adicionar a lib lodash
ela tem varia utilidades exemplo unique ID, debounce, varias funções para manipular arrays e objetos, vamos fazer uso da uniqueId
por que estou usando esse ID único por que cada dentro de uma lista do react, a gente sabe que precisar ter aquela propriedade
Key essa key e como se fosse um identificador, um item único dentro de um array, quando a gente importa esse file não podemos falar que a key e o nome do file, se o usuário for lá e fizer upload de dois arquivos com o mesmo nome, vai dar problema, então no id vamos gerar o uniqueId.